### PR TITLE
Enable docker service on boot

### DIFF
--- a/proxy/scripts/install-fyde-proxy-docker.sh
+++ b/proxy/scripts/install-fyde-proxy-docker.sh
@@ -48,10 +48,17 @@ if ! docker version &> /dev/null
 then
     curl -fsSL "$DL_DOCKER" -o get-docker.sh
     sh get-docker.sh
-    systemctl start docker
 else
     log_entry "WARNING" "Docker detected, skipping install"
 fi
+
+log_entry "INFO" "Enable docker service on boot"
+
+systemctl enable docker
+
+log_entry "INFO" "Starting docker"
+
+systemctl start docker
 
 # Instal docker-compose
 


### PR DESCRIPTION
CentOS doesn't enable docker service on boot when installing, setting on for all distributions.

Changes tested in:
- Ubuntu 16.04
- Ubuntu 18.04
- CentOS 7