### PR TITLE
Fix config baseurl and url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 remote_theme: pmarsceill/just-the-docs
 title: Fyde Docs
-baseurl: /docs/
+baseurl: /docs
 url: https://fydeinc.github.io
 description: Documentation for the Fyde Enterprise Console
 permalink: pretty


### PR DESCRIPTION
Base url does not need trailing slash:

![Screen Shot 2019-07-27 at 6 03 21 PM](https://user-images.githubusercontent.com/374130/62000940-feed6880-b098-11e9-851e-b5edfdb1b403.png)
