### PR TITLE
Add instructions and change script to include the CAP_NET_BIND_SERVICE 

### DIFF
--- a/fyde-access-proxy/install-bm-vm.md
+++ b/fyde-access-proxy/install-bm-vm.md
@@ -46,6 +46,30 @@ nav_order: 1
     ```sh
     sudo yum -y install envoy
     sudo systemctl enable envoy
+    ```
+
+1. Add CAP_NET_BIND_SERVICE to Envoy using a service unit override
+
+    If you choose to configure your proxy to run in a port below 1024,
+    you will need to add the CAP_NET_BIND_SERVICE capability to Envoy.
+
+    ```sh
+    sudo mkdir -p /etc/systemd/system/envoy.service.d
+
+    sudo bash -c "cat > /etc/systemd/system/envoy.service.d/10-add-cap-net-bind.conf <<EOF
+    [Service]
+    Capabilities=CAP_NET_BIND_SERVICE+ep
+    CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+    AmbientCapabilities=CAP_NET_BIND_SERVICE
+    SecureBits=keep-caps
+    EOF"
+
+    sudo chmod 600 /etc/systemd/system/envoy.service.d/10-add-cap-net-bind.conf
+    ```
+
+1. Reload and start Envoy Proxy
+    ```sh
+    sudo systemctl --system daemon-reload
     sudo systemctl start envoy
     ```
 

--- a/fyde-access-proxy/scripts/install-fyde-proxy-centos.sh
+++ b/fyde-access-proxy/scripts/install-fyde-proxy-centos.sh
@@ -44,6 +44,25 @@ log_entry "INFO" "Install Envoy Proxy"
 
 yum -y install envoy
 systemctl enable envoy
+
+if [ $PUBLIC_PORT -lt 1024 ];
+then
+    log_entry "INFO" "Add CAP_NET_BIND_SERVICE to Envoy using a service unit override"
+
+    mkdir -p /etc/systemd/system/envoy.service.d
+    cat > /etc/systemd/system/envoy.service.d/10-add-cap-net-bind.conf <<EOF
+[Service]
+Capabilities=CAP_NET_BIND_SERVICE+ep
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+SecureBits=keep-caps
+EOF
+    chmod 600 /etc/systemd/system/envoy.service.d/10-add-cap-net-bind.conf
+fi
+
+log_entry "INFO" "Reload and start Envoy Proxy"
+
+systemctl --system daemon-reload
 systemctl start envoy
 
 log_entry "INFO" "Install Fyde Proxy Orchestrator and authz system"


### PR DESCRIPTION
When binding below 1024, we need to add the CAP_NET_BIND_SERVICE capability to the Envoy service unit, since envoy runs as non-root from start.

This PR adds this conditional step to the documentation and to the centos install script.

Tested on Centos 7.